### PR TITLE
Better citation support

### DIFF
--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,11 @@
+bibentry(
+  bibtype  = "Article",
+  title    = "densify: An R package to prune sparse data frames of typological linguistic data",
+  author   = "Anna Graf, Marc Lischka, Taras Zakharko, Reinhard Furrer, Balthasar Bickel",
+  journal  = "JOSS",
+  year     = "2024",
+  volume   = "",
+  number   = "",
+  pages    = "",
+  doi      = ""
+)


### PR DESCRIPTION
This adds citation information so that  `citation("densify")` is rendered as thus:

```
To cite package ‘densify’ in publications use:

  Graf A, Lischka M, Zakharko T, Furrer R, Bickel B (2024). “densify: An R package to prune sparse data frames of typological linguistic data.” _JOSS_.

A BibTeX entry for LaTeX users is

  @Article{,
    title = {densify: An R package to prune sparse data frames of typological linguistic data},
    author = {Anna Graf and Marc Lischka and Taras Zakharko and Reinhard Furrer and Balthasar Bickel},
    journal = {JOSS},
    year = {2024},
  }
```

To modify the citation, edit the file `inst/CITATION`, reinstall the package, and check `citation("densify")`
