### PR TITLE
More control for pruning if scoring identifies equal candidates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,7 @@ Imports:
     stats
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 LazyData: true
 Suggests: 
     ggplot2,

--- a/R/rank.R
+++ b/R/rank.R
@@ -53,13 +53,15 @@ generics::rank_results
 #' @param scoring_function an expression that computes a densification quality score. The default maximizes the product of
 #'   the number of data points and the coding density. See [densify_result] for available statistics that can
 #'   be used to compute a suitable scoring_function
+#' @param multiple how to resolve equal scores
 #'
 #' @return the densified data frame
 #'
 #' @importFrom generics prune
 #' @export
-prune.densify_result <- function(tree, ..., scoring_function = n_data_points * coding_density) {
-  check_dots_unnamed()
+prune.densify_result <- function(tree, ..., scoring_function = n_data_points * coding_density, multiple = c("warn", "first", "random")) {
+  check_dots_empty()
+  multiple <- arg_match(multiple)
 
   n_data_points <- coding_density <- NULL
 
@@ -70,8 +72,11 @@ prune.densify_result <- function(tree, ..., scoring_function = n_data_points * c
   length(best) > 0L || cli::cli_abort("no ranking can be established, aborting")
 
   if (length(best) > 0) {
-    best <- best[[1L]]
-    cli::cli_warn("in {.fn prune}: multiple best matches, returning the first one at index {.field {best}}")
+    best <- if (multiple == "random") sample(best, 1L) else best[[1]]
+
+    if (multiple == "warn") cli::cli_warn(
+      "in {.fn prune}: multiple best matches, returning the first one at index {.field {best}}"
+    )
   }
 
   # return the pruned data set

--- a/man/prune.densify_result.Rd
+++ b/man/prune.densify_result.Rd
@@ -4,7 +4,12 @@
 \alias{prune.densify_result}
 \title{Obtain densified data frame that maximizes a quality scoring function}
 \usage{
-\method{prune}{densify_result}(tree, ..., scoring_function = n_data_points * coding_density)
+\method{prune}{densify_result}(
+  tree,
+  ...,
+  scoring_function = n_data_points * coding_density,
+  multiple = c("warn", "first", "random")
+)
 }
 \arguments{
 \item{tree}{a \link{densify_result} object}
@@ -14,6 +19,8 @@
 \item{scoring_function}{an expression that computes a densification quality score. The default maximizes the product of
 the number of data points and the coding density. See \link{densify_result} for available statistics that can
 be used to compute a suitable scoring_function}
+
+\item{multiple}{how to resolve equal scores}
 }
 \value{
 the densified data frame


### PR DESCRIPTION
Added the `multiple` argument to `prune()` for controlling the pruning behavior if multiple candidates have the same score

Closes #22 